### PR TITLE
Add workflow for pdf build and release

### DIFF
--- a/.github/workflows/build-latex.yml
+++ b/.github/workflows/build-latex.yml
@@ -1,0 +1,46 @@
+name: Build LaTeX document
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: type-systems.tex
+      - name: Rename file
+        id: rename_file
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          datetime_now=$(date +'%Y-%m-%dT%H:%M:%S')
+          filename=type-systems-$datetime_now-$sha_short.pdf
+          echo "filename=$filename" >> $GITHUB_OUTPUT
+          echo "sha_short=$sha_short" >> $GITHUB_OUTPUT
+          mv type-systems.pdf $filename
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.rename_file.outputs.sha_short }}
+          release_name: Release ${{ steps.rename_file.outputs.filename }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.rename_file.outputs.filename }}
+          asset_name: ${{ steps.rename_file.outputs.filename }}
+          asset_content_type: application/pdf


### PR DESCRIPTION
This PR adds workflow for building pdf and publishing them
- It runs after ever push (that includes PR merges) to master (It may be also triggered manually)
- After every build new release with built pdf is created
- AFAIK Github requires tags for every commit that has associated release (or at least I wasn't able to bypass that), so every release commit gets tagged with it's own short hash
- Every release and pdf in release is named according to format `type-systems-<build datetime>-<short commit hash>`
- This action produces some warnings, but we're not building critical infrastructure so I suppose it's okay for now